### PR TITLE
Remove duplicate definiton of game_won

### DIFF
--- a/main.c
+++ b/main.c
@@ -96,7 +96,6 @@ SDL_Surface *screen;
 TTF_Font *font;
 int lastmousex, lastmousey;
 char *player_name;
-int game_won;
 int state;
 
 struct button_s {


### PR DESCRIPTION
It is already defined in game.c and declared in game.h.

This patch fixes the linker error "multiple definition of `game_won'".
