### PR TITLE
Place the server closer to the center

### DIFF
--- a/main.c
+++ b/main.c
@@ -1080,7 +1080,7 @@ void update_time()
 void resize()
 //position everything based on board size
 {
-    sourcex = boardw / 2 - 1;
+    sourcex = (boardw - 1) / 2;
     sourceytop =  boardh / 2;
     sourceybottom = sourceytop + 1;
     int w = cellw * boardw + (boardw + 1) * border + 2 * padding;


### PR DESCRIPTION
This places the server exactly in the center of the map on the horizontal
axis for maps with odd number of columns.  Previously it was placed off
by one to the left. For example, on the "Newbie" level, it resulted in
`sourcex = 5 / 2 - 1 = 1` instead of the center column 2.

For maps with even number of columns, server placement is not changed.
